### PR TITLE
add meta tags

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,20 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
+        <meta property="og:title" content="Introducing SE" />
+        <meta property="og:description" content='Introducing Se description.' />
+        <meta property="og:url" content="https://introducing.se/" />
+        <meta property="og:image" content="https://introducing.se/dist/media/street-epistemology-logo.png" />
+        <meta property="og:site_name" content='Introducing Se description.' />
+        <meta property="og:locale" content="en_US" />
+        <meta property="og:type" content="article" />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content='Introducing Se description.' />
+        <meta name="twitter:description" content="Introducing SE" />
+        <meta name="twitter:site" content="https://introducing.se/" />
+        <meta name="twitter:image" content="https://introducing.se/dist/media/street-epistemology-logo.png" />
+        <meta name="twitter:creator" content="@twitter" />
+
 <title>To talk about anything</title>
 		<link rel="stylesheet" href="dist/reset.css">
 		<link rel="stylesheet" href="dist/reveal.css">


### PR DESCRIPTION
This image may look broken in cases.
![example](https://media.discordapp.net/attachments/226539449226362881/1096348714894884885/image.png?width=814&height=289)

> OG Image Size: The recommended size for an OG Image is 1.91:1. The recommended pixel dimensions of 1200:630 px (aspect ratio of 1.91:1). 

[read more](https://www.kapwing.com/resources/what-is-an-og-image-make-and-format-og-images-for-your-blog-or-webpage/)

> For a twitter:card tag set to summary, it supports square images (set via the twitter:image tag) that are sized between 144x144 and 4096x4096 pixels.
> For the summary_large_image setting, rectangular images are supported too, between 300x157 and 4096x4096 pixels.

[read more](https://www.everywheremarketer.com/blog/ultimate-guide-to-social-meta-tags-open-graph-and-twitter-cards)